### PR TITLE
Improve Swift's compatibility

### DIFF
--- a/Swift/BetterNinebotCrypto.swift
+++ b/Swift/BetterNinebotCrypto.swift
@@ -123,14 +123,19 @@ class NinebotCrypto {
                 }
                 self.calcKey(Data(deviceName.utf8), randomBLEData)
             }
-        } else if newMessageCounter > messageCounter {
+        } else {
             if decrypted.starts(with: self.cryptoReadyMessage) {
                 let randomAppData = self.randomAppData ?? Data(count: 8)
                 let randomBLEData = self.randomBLEData ?? Data(count: 8)
                 self.calcKey(randomAppData, randomBLEData)
                 self.printDebug("Crypto ready")
             }
-            self.messageCounter = newMessageCounter
+            
+            if newMessageCounter > messageCounter {
+                self.messageCounter = newMessageCounter
+            } else {
+                self.messageCounter += 1
+            }
         }
 
         return decrypted


### PR DESCRIPTION
A user reported the current auth code not working on iOS but working in SHUT (which uses the Kotlin implementation of this library) with their F2 Pro. What they observed is the crypto counter going backwards after auth. Kotlin mitigated that by running the auth completion code regardless of whether the counter went down or not, and then afterwards incrementing it if it went down. I was given a sample patch that did pretty much what I did in this PR just a jankier way and was told it worked, so this is just a rewrite of that. Still runs perfectly on my G30P and Pro2, and should be running on the reported scooter too given this patch implements similar logic, so should be good to merge. Thx!